### PR TITLE
Allow multi-value labels and clarify the distinction between tags and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata.
+- Allowed non-empty arrays of strings, numbers, and booleans as label values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata.
-- Allowed non-empty arrays of strings, numbers, and booleans as label values.
+- Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata ([#54](https://github.com/ctrf-io/ctrf/pull/54)).
+- Allowed non-empty arrays of strings, numbers, and booleans as label values ([#54](https://github.com/ctrf-io/ctrf/pull/54)).

--- a/examples/comprehensive.json
+++ b/examples/comprehensive.json
@@ -44,7 +44,9 @@
           "priority": "P1",
           "severity": 2,
           "automated": true,
-          "externalId": 45678
+          "externalId": 45678,
+          "owners": ["qa", "platform"],
+          "category": ["smoke", "staging"]
         },
         "filePath": "tests/auth/login.test.js",
         "browser": "chromium",

--- a/schema/ctrf.schema.json
+++ b/schema/ctrf.schema.json
@@ -190,17 +190,44 @@
                 "type": "string"
               },
               "tags": {
-                "description": "User-defined tags",
+                "description": "Simple keyless classifications associated with the test case",
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
               "labels": {
-                "description": "Structured key-value metadata for the test case (e.g. priority, severity, external identifiers)",
+                "description": "Structured key-value metadata for the test case. Values may be scalar primitives or non-empty arrays of primitive values",
                 "type": "object",
                 "additionalProperties": {
-                  "type": [ "string", "number", "boolean" ]
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               },
               "type": {

--- a/schema/ctrf.schema.json
+++ b/schema/ctrf.schema.json
@@ -197,7 +197,7 @@
                 }
               },
               "labels": {
-                "description": "Structured key-value metadata describing the test case. Values may be scalar primitives or non-empty arrays of primitive values.",
+                "description": "Structured key-value metadata describing the test case. Values may be scalar primitives or non-empty arrays of primitive values",
                 "type": "object",
                 "additionalProperties": {
                   "anyOf": [

--- a/schema/ctrf.schema.json
+++ b/schema/ctrf.schema.json
@@ -190,14 +190,14 @@
                 "type": "string"
               },
               "tags": {
-                "description": "Simple keyless classifications associated with the test case",
+                "description": "Simple, keyless classifications used to categorize the test case",
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
               "labels": {
-                "description": "Structured key-value metadata for the test case. Values may be scalar primitives or non-empty arrays of primitive values",
+                "description": "Structured key-value metadata describing the test case. Values may be scalar primitives or non-empty arrays of primitive values.",
                 "type": "object",
                 "additionalProperties": {
                   "anyOf": [

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -2011,14 +2011,14 @@ to this specification.
                 "type": "string"
               },
               "tags": {
-                "description": "Simple keyless classifications associated with the test case",
+                "description": "Simple, keyless classifications used to categorize the test case",
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
               "labels": {
-                "description": "Structured key-value metadata for the test case. Values may be scalar primitives or non-empty arrays of primitive values",
+                "description": "Structured key-value metadata describing the test case. Values may be scalar primitives or non-empty arrays of primitive values",
                 "type": "object",
                 "additionalProperties": {
                   "anyOf": [

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -856,13 +856,14 @@ A list of simple, keyless classifications associated with the test.
 **Requirements:**  
 `tags` is OPTIONAL.  
 If present, it MUST be an array of strings.  
-Producers SHOULD use `tags` for keyless categorization, such as `"smoke"`, `"regression"`, or `"api"`.  
-Metadata that has a named key and one or more associated values SHOULD use `labels` instead.
+Producers SHOULD use `tags` for simple, keyless categorization, such as `"smoke"`, `"regression"`, or `"nightly"`. Metadata consisting of named attributes and associated values SHOULD use `labels` instead.
+
+---
 
 ### 9.15. `labels`
 
 **Description:**  
-Structured key-value metadata associated with the test, including framework traits, classification, ownership, and external system integration (for example, priority, severity, owner, category, or external identifiers).
+Structured key-value metadata associated with the test, such as ownership, priority, severity, external identifiers, or other named attributes.
 
 **Requirements:**  
 `labels` is OPTIONAL.  
@@ -870,20 +871,7 @@ If present, it MUST be an object.
 Each value MUST be either a string, number, or boolean, or a non-empty array containing those primitive types.  
 Array values MAY contain more than one primitive type, but producers SHOULD use a consistent primitive type for all values associated with a label key.  
 Consumers MUST treat label keys as opaque and MUST NOT require any particular keys to be present.  
-Producers SHOULD use `labels` rather than `tags` when the metadata has a named key or may contain multiple values.
-
-Example:
-
-```json
-{
-  "tags": ["smoke", "regression", "api"],
-  "labels": {
-    "priority": "high",
-    "owners": ["qa", "platform"],
-    "category": ["smoke", "staging"]
-  }
-}
-```
+Producers SHOULD use `labels` whenever the metadata consists of named attributes and associated values.
 
 ### 9.16. `type`
 

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -851,22 +851,39 @@ If present, it MUST be a string.
 ### 9.14. `tags`
 
 **Description:**  
-A list of user-defined tags associated with the test.
+A list of simple, keyless classifications associated with the test.
 
 **Requirements:**  
 `tags` is OPTIONAL.  
-If present, it MUST be an array of strings.
+If present, it MUST be an array of strings.  
+Producers SHOULD use `tags` for keyless categorization, such as `"smoke"`, `"regression"`, or `"api"`.  
+Metadata that has a named key and one or more associated values SHOULD use `labels` instead.
 
 ### 9.15. `labels`
 
 **Description:**  
-Structured key-value metadata, commonly used for classification and external system integration (e.g. priority, severity, external identifiers).
+Structured key-value metadata associated with the test, including framework traits, classification, ownership, and external system integration (for example, priority, severity, owner, category, or external identifiers).
 
 **Requirements:**  
 `labels` is OPTIONAL.  
 If present, it MUST be an object.  
-Each value MUST be one of: string, number, or boolean.  
-Consumers MUST treat label keys as opaque and MUST NOT require any particular keys to be present.
+Each value MUST be either a string, number, or boolean, or a non-empty array containing those primitive types.  
+Array values MAY contain more than one primitive type, but producers SHOULD use a consistent primitive type for all values associated with a label key.  
+Consumers MUST treat label keys as opaque and MUST NOT require any particular keys to be present.  
+Producers SHOULD use `labels` rather than `tags` when the metadata has a named key or may contain multiple values.
+
+Example:
+
+```json
+{
+  "tags": ["smoke", "regression", "api"],
+  "labels": {
+    "priority": "high",
+    "owners": ["qa", "platform"],
+    "category": ["smoke", "staging"]
+  }
+}
+```
 
 ### 9.16. `type`
 
@@ -2006,17 +2023,44 @@ to this specification.
                 "type": "string"
               },
               "tags": {
-                "description": "User-defined tags",
+                "description": "Simple keyless classifications associated with the test case",
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
               "labels": {
-                "description": "Structured key-value metadata for the test case (e.g. priority, severity, external identifiers)",
+                "description": "Structured key-value metadata for the test case. Values may be scalar primitives or non-empty arrays of primitive values",
                 "type": "object",
                 "additionalProperties": {
-                  "type": [ "string", "number", "boolean" ]
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          }
+                        ]
+                      }
+                    }
+                  ]
                 }
               },
               "type": {
@@ -2960,6 +3004,12 @@ It includes:
         "name": "user can log in",
         "suite": ["auth", "login"],
         "filePath": "tests/auth/login.test.js",
+        "tags": ["smoke", "authentication"],
+        "labels": {
+          "priority": "high",
+          "owners": ["qa", "platform"],
+          "category": ["smoke", "staging"]
+        },
         "status": "passed",
         "duration": 3000,
         "retries": 1,

--- a/tests/normative/type-validation.test.json
+++ b/tests/normative/type-validation.test.json
@@ -471,8 +471,8 @@
       }
     },
     {
-      "description": "Test with labels containing invalid value type (array)",
-      "valid": false,
+      "description": "Test with valid labels containing string array values",
+      "valid": true,
       "data": {
         "reportFormat": "CTRF",
         "specVersion": "1.0.0",
@@ -480,6 +480,84 @@
           "tool": { "name": "runner" },
           "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
           "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "priority": ["P1", "P2"] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with valid labels containing number array values",
+      "valid": true,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "externalIds": [123, 456] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with valid labels containing boolean array values",
+      "valid": true,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "featureFlags": [true, false] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with valid labels containing mixed primitive array values",
+      "valid": true,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "sourceValues": ["manual", 2, true] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with labels containing an empty array value",
+      "valid": false,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "owners": [] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with labels containing an object in an array value",
+      "valid": false,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "owners": ["qa", { "team": "platform" }] } }]
+        }
+      }
+    },
+    {
+      "description": "Test with labels containing null in an array value",
+      "valid": false,
+      "data": {
+        "reportFormat": "CTRF",
+        "specVersion": "1.0.0",
+        "results": {
+          "tool": { "name": "runner" },
+          "summary": { "tests": 1, "passed": 1, "failed": 0, "pending": 0, "skipped": 0, "other": 0, "start": 1609459200000, "stop": 1609459201000 },
+          "tests": [{ "name": "test", "status": "passed", "duration": 100, "labels": { "owners": ["qa", null] } }]
         }
       }
     },


### PR DESCRIPTION
## Summary

Clarifies the intended role of `labels` in CTRF, confirms support for multi-value label values, and documents the relationship between `labels` and `tags`.

This PR implements the following direction:

- `labels` are the correct place for structured key/value test metadata
- label values may be scalar primitives or arrays for multi-valued metadata
- `tags` remain alongside `labels` as the simple keyless categorization field

## Context

`labels` are intended for structured key/value test metadata. This includes trait-style metadata emitted by frameworks, not only a narrow administrative subset.

Examples of label-style metadata include:

- `priority`
- `severity`
- external identifiers
- `owner`
- `category`
- similar structured framework or user-defined metadata

## Tags vs Labels

This PR keeps both fields and clarifies that they are complementary:

- `tags` = simple, keyless classifications
- `labels` = structured key/value metadata

For example, `tags` remain appropriate for simple categorization:

```json
"tags": ["smoke", "regression", "api"]
```

Whereas `labels` are appropriate when the metadata has named attributes and associated values:

```json
"labels": {
  "priority": "high",
  "owner": "qa"
}
```

This PR is not about replacing `tags` with `labels`. It preserves a simple categorization mechanism while supporting richer structured metadata for producers that have it.

## Multi-Value Labels

A single label key may legitimately have multiple values and should be CTRF-compliant.

This PR updates the schema and spec so label values may be:

- a scalar string, number, or boolean
- a non-empty array containing string, number, or boolean values

Example:

```json
"labels": {
  "priority": "high",
  "owners": ["qa", "platform"],
  "category": ["smoke", "staging"]
}
```

The implementation allows arrays containing the same primitive types as scalar label values:

- `string`
- `number`
- `boolean`

The spec also gives producer guidance that array values may contain more than one primitive type, but producers should use a consistent primitive type for all values associated with a label key.

## Why This Matters

Different test frameworks expose metadata differently.

Some provide keyless tags or categories. Others provide named traits or labels, sometimes with multiple values per key.

Without a clear model, producers may diverge by putting the same concepts into different places, such as:

- `tags`
- `labels`
- `extra.traits`
- flattened strings

That weakens interoperability across reporters and consumers.

This PR makes the model explicit, reducing pressure for ad hoc conventions in `extra` while keeping the core schema small and understandable.

## Implementation Details

This PR updates:

- `schema/ctrf.schema.json`
  - clarifies `tags` as simple keyless classifications
  - clarifies `labels` as structured key/value metadata
  - allows label values to be scalar primitives or non-empty arrays of primitive values

- `spec/ctrf.md`
  - documents the `tags` vs `labels` distinction
  - states that `labels` values may be scalar primitives or non-empty primitive arrays
  - adds guidance for producer consistency when using array values
  - keeps consumers treating label keys as opaque

- `examples/comprehensive.json`
  - demonstrates scalar label values alongside multi-value labels such as `owners` and `category`

- `tests/normative/type-validation.test.json`
  - keeps invalid coverage for labels as non-object values
  - adds valid coverage for string, number, boolean, and mixed primitive arrays
  - adds invalid coverage for empty arrays, object values inside arrays, and null values inside arrays

- `CHANGELOG.md`
  - records the backward-compatible clarification and schema expansion under `Unreleased`

## Resolved Implementation Questions

- Mixed primitive arrays are schema-valid, but producers should keep values homogeneous per label key where practical.
- Empty arrays are not allowed.
- This change keeps `labels` test-level only; it does not introduce broader label placement.

## Compatibility

This is a backward-compatible schema relaxation and clarification.

Existing scalar label values remain valid. Existing `tags` behavior remains valid. The new behavior only allows additional valid label value shapes for producers that need multi-valued structured metadata.

## Validation

- `jsonschema lint schema/ctrf.schema.json --exclude top_level_examples`
- `jsonschema test tests/normative`
- `jsonschema test tests/informative`
- `jsonschema validate schema/ctrf.schema.json examples/*.json`
- `jsonschema test tests/ctrf.test.json`
