### PR TITLE
Add immutability principle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added immutability guidance for emitted CTRF report artifacts.
+- Added immutability guidance for emitted CTRF report artifacts ([#55](https://github.com/ctrf-io/ctrf/pull/55)).
 - Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata ([#54](https://github.com/ctrf-io/ctrf/pull/54)).
 - Allowed non-empty arrays of strings, numbers, and booleans as label values ([#54](https://github.com/ctrf-io/ctrf/pull/54)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added immutability guidance for emitted CTRF report artifacts ([#55](https://github.com/ctrf-io/ctrf/pull/55)).
+- Clarified immutability guidance for emitted CTRF report artifacts ([#55](https://github.com/ctrf-io/ctrf/pull/55)).
 - Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata ([#54](https://github.com/ctrf-io/ctrf/pull/54)).
 - Allowed non-empty arrays of strings, numbers, and booleans as label values ([#54](https://github.com/ctrf-io/ctrf/pull/54)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added immutability guidance for emitted CTRF report artifacts.
 - Clarified `tags` as simple keyless classifications and `labels` as structured key-value test metadata ([#54](https://github.com/ctrf-io/ctrf/pull/54)).
 - Allowed non-empty arrays of strings, numbers, and booleans as label values ([#54](https://github.com/ctrf-io/ctrf/pull/54)).

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -252,7 +252,7 @@ Immutability supports:
 - compatibility with hashing, signing, and deduplication
 - clear separation between raw results and derived results
 
-When a tool or system performs additional processing after initial report generation — such as merging shard reports, adding metadata, or computing insights — the design intent is that this produces a new CTRF document with a new `reportId`, rather than modifying the original.
+When a tool or system performs additional processing after initial report generation — such as merging shard reports, adding metadata, or computing insights — the design intent is that this produces a new CTRF document and, when `reportId` is used, assigns a different `reportId` value, rather than modifying the original.
 
 This distinction between the act of constructing a report and the resulting artifact as an immutable record is central to how CTRF is designed to be used in pipelines, artifact stores, and analysis systems.
 
@@ -425,7 +425,7 @@ A unique identifier for this report instance.
 `reportId` is OPTIONAL.  
 If present, it MUST be a valid UUID as defined in [RFC4122].
 
-Each emitted CTRF document represents a distinct report instance. If a new CTRF document is produced through post-processing, it SHOULD receive a new `reportId`.
+Each emitted CTRF document represents a distinct report instance. If a new CTRF document is produced through post-processing, it SHOULD use a different `reportId` value than the source document when `reportId` is used.
 
 ---
 
@@ -1787,7 +1787,7 @@ Producers:
 - MUST NOT emit invalid enum values (status, etc.)
 - MAY include `insights` if historical or aggregate data is available
 - SHOULD treat emitted CTRF documents as immutable artifacts
-- SHOULD emit a new CTRF document with a new `reportId` when performing post-processing after initial report generation, rather than modifying an emitted CTRF document
+- SHOULD emit a new CTRF document when performing post-processing after initial report generation and, when `reportId` is used, assign a different `reportId` value rather than modifying an emitted CTRF document
 
 Producers SHOULD:
 

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -1786,14 +1786,14 @@ Producers:
 - MUST NOT introduce fields outside `extra` objects  
 - MUST NOT emit invalid enum values (status, etc.)
 - MAY include `insights` if historical or aggregate data is available
-- SHOULD treat emitted CTRF documents as immutable artifacts
-- SHOULD emit a new CTRF document when performing post-processing after initial report generation and, when `reportId` is used, assign a different `reportId` value rather than modifying an emitted CTRF document
 
 Producers SHOULD:
 
 - provide timestamps  
 - provide environment/build metadata  
 - provide diagnostics when available  
+- treat emitted CTRF documents as immutable artifacts
+- emit a new CTRF document when performing post-processing after initial report generation and, when `reportId` is used, assign a different `reportId` value rather than modifying an emitted CTRF document
 
 ---
 

--- a/spec/ctrf.md
+++ b/spec/ctrf.md
@@ -238,6 +238,26 @@ As long as the document structure and semantics are respected, CTRF does not con
 
 ---
 
+### 2.11. Immutable Report Artifacts
+
+CTRF treats an emitted report as an immutable artifact.
+
+A CTRF document represents a snapshot of test results at the time it is produced. Implementations are free to build or transform documents internally before emission, but once a CTRF document has been written, published, or otherwise made available as an artifact, it is treated as a fixed record.
+
+Immutability supports:
+
+- auditability of test results
+- reproducibility of analysis
+- stable caching and artifact storage
+- compatibility with hashing, signing, and deduplication
+- clear separation between raw results and derived results
+
+When a tool or system performs additional processing after initial report generation — such as merging shard reports, adding metadata, or computing insights — the design intent is that this produces a new CTRF document with a new `reportId`, rather than modifying the original.
+
+This distinction between the act of constructing a report and the resulting artifact as an immutable record is central to how CTRF is designed to be used in pipelines, artifact stores, and analysis systems.
+
+---
+
 ## 3. Terminology
 
 The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHALL**, **SHALL NOT**,  
@@ -404,6 +424,8 @@ A unique identifier for this report instance.
 **Requirements:**  
 `reportId` is OPTIONAL.  
 If present, it MUST be a valid UUID as defined in [RFC4122].
+
+Each emitted CTRF document represents a distinct report instance. If a new CTRF document is produced through post-processing, it SHOULD receive a new `reportId`.
 
 ---
 
@@ -1764,6 +1786,8 @@ Producers:
 - MUST NOT introduce fields outside `extra` objects  
 - MUST NOT emit invalid enum values (status, etc.)
 - MAY include `insights` if historical or aggregate data is available
+- SHOULD treat emitted CTRF documents as immutable artifacts
+- SHOULD emit a new CTRF document with a new `reportId` when performing post-processing after initial report generation, rather than modifying an emitted CTRF document
 
 Producers SHOULD:
 
@@ -1784,6 +1808,8 @@ Consumers:
 - MUST NOT require optional fields to be present
 - MUST NOT assume the presence of `insights`
 - SHOULD compute insights when sufficient historical data is available
+- SHOULD assume that CTRF documents are immutable once emitted
+- MUST NOT rely on in-place modification of existing reports
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an immutability principle to the CTRF specification.

The core idea is that an emitted CTRF report should be treated as an immutable artifact: a fixed snapshot of test results at the time it was produced. Producers can still build or transform reports internally before emission, but once a report has been written, published, uploaded, or otherwise made available as an artifact, consumers and downstream systems should treat it as stable.

## Why This Matters

Immutability gives CTRF reports stronger artifact semantics for CI systems, report stores, dashboards, and downstream analysis.

It supports:

- auditability of test results
- reproducibility of analysis
- stable caching and artifact storage
- compatibility with hashing, signing, and deduplication
- a clearer separation between raw emitted results and derived reports

This is especially important for workflows that merge shards, enrich report metadata, compute insights, or otherwise post-process test output after initial report generation.

## Behavior Clarified

This PR clarifies that post-processing should produce a new CTRF document rather than mutate an already-emitted one.

Examples of post-processing include:

- merging shard reports
- adding metadata after initial generation
- computing derived insights
- producing a derived or enriched report for another system

When a new CTRF document is produced through that kind of post-processing, it should receive a new `reportId`.

## Implementation Details

This PR updates `spec/ctrf.md` only, plus the changelog.

Spec changes:

- Adds Section `2.11` `Immutable Report Artifacts`
- Adds a `reportId` note in Section `5.3`
- Adds producer conformance guidance:
  - producers should treat emitted CTRF documents as immutable artifacts
  - producers should emit a new CTRF document with a new `reportId` when post-processing after initial report generation
- Adds consumer conformance guidance:
  - consumers should assume CTRF documents are immutable once emitted
  - consumers must not rely on in-place modification of existing reports

Changelog changes:

- Adds an Unreleased entry for the immutability guidance

## Compatibility

This is a documentation/specification clarification. It does not change the JSON Schema and does not alter document validation.

The change strengthens the intended artifact model without invalidating existing CTRF documents.

## Validation

- `jsonschema validate schema/ctrf.schema.json examples/*.json`
- `jsonschema test tests/ctrf.test.json`
- `jsonschema test tests/normative`
- `jsonschema test tests/informative`
